### PR TITLE
fix issue w/ i18n initialization

### DIFF
--- a/src/features/auth/utils/registerFormSchema.ts
+++ b/src/features/auth/utils/registerFormSchema.ts
@@ -1,7 +1,7 @@
-import { t } from 'i18next';
 import { z } from 'zod';
 import { toFormikValidationSchema } from 'zod-formik-adapter';
 
+import i18n from '@/lib/i18n';
 import { translationWithPrefix } from '@/utils/translationWithPrefix';
 
 import {
@@ -29,7 +29,7 @@ enum Fields {
 const tp = translationWithPrefix('error.validations');
 
 const getLocalizedMessage = (key: Errors, field: Fields, value?: object) =>
-  String(tp(key, { field: t(`auth.register.${field}.label`), ...value }));
+  String(tp(key, { field: i18n.t(`auth.register.${field}.label`), ...value }));
 
 const getErrorConfig = (key: Errors, field: Fields, value?: object) => ({
   message: getLocalizedMessage(key, field, value),

--- a/src/lib/errorHandler.ts
+++ b/src/lib/errorHandler.ts
@@ -1,5 +1,4 @@
-import { t } from 'i18next';
-
+import i18n from '@/lib/i18n';
 import { customToast } from '@/utils/customStandaloneToast';
 
 const getErrorMessage = (error: unknown) => {
@@ -11,7 +10,7 @@ class ErrorHandler {
   reportError = (error: unknown) => {
     console.error(error);
     customToast({
-      title: String(t('error.genericError')),
+      title: String(i18n.t('error.genericError')),
       description: getErrorMessage(error),
       status: 'error',
       duration: 9000,

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -13,3 +13,5 @@ i18n.use(initReactI18next).init({
     },
   },
 });
+
+export default i18n;

--- a/src/utils/translationWithPrefix.ts
+++ b/src/utils/translationWithPrefix.ts
@@ -1,4 +1,6 @@
-import { t, TFunction, TFunctionKeys, TOptions } from 'i18next';
+import { TFunction, TFunctionKeys, TOptions } from 'i18next';
+
+import i18n from '@/lib/i18n';
 
 /**
  * @param prefix string
@@ -7,4 +9,4 @@ import { t, TFunction, TFunctionKeys, TOptions } from 'i18next';
 export const translationWithPrefix = (prefix: string) => (
   suffix: TFunctionKeys,
   options?: TOptions
-): TFunction => t(`${prefix}.${suffix}`, options);
+): TFunction => i18n.t(`${prefix}.${suffix}`, options);


### PR DESCRIPTION
## Links:
<!--- At a minimum include a link to the Ticket it implements --->

* [Trello Card](https://trello.com/c/tz7HNB2a/2-bug-fix-undefined-appearing-as-error-message)

## What & Why:
<!--- Describe the changes being made and why they're useful --->

Fixed issue on error message displaying `undefined`.

**Cause:** 
Using i18n as standalone (outside the JSX/ without the `useTranslation` hook) caused the library to work uninitialized. 

**Solution:**
The standard solution appears to be _to re-export `i18n` once initialized and use that_. I did exactly that and changed the imports on standalone `i18n` use cases.

<!--- Screenshots are expected for UI changes... right? ಠ_ಠ --->
**Screenshot:**

![image](https://user-images.githubusercontent.com/67912621/168091271-0a22f980-f301-4463-9c13-cb5827c71370.png)


## Risks, Mitigation & Rollback:
<!--- What risks exist for these new changes and what steps to mitigate them have been taken? --->
<!--- What steps are necessary to rollback this code safely? --->

- [ ] Safe to Revert *check this box if this PR can be reverted without incident*
